### PR TITLE
easysplash: add github CI actions support

### DIFF
--- a/.github/workflows/easysplash.yml
+++ b/.github/workflows/easysplash.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: install dependencies
+      run: sudo apt-get install -y libsystemd-dev
+    - name: make
+      run: |
+        mkdir build
+        cmake -S . -B build -DDISPLAY_TYPE_SWRENDER=1
+        cmake --build build


### PR DESCRIPTION
This commit add a simple yaml file to support CI
in easysplash.

Closes #1

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>