### PR TITLE
Add support for animation part which will be played forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ The animation view port is always rendered on the center of screen. The parts ar
 available:
 
 - `file`: specifies the file to use for the part (required).
-- `mode`: is either `complete` or `interruptable`. (optional)
+- `mode`: is `complete`, `interruptable` or `forever`. (optional)
     - `complete` means the part must be played completely, even if somebody requested EasySplash to
       stop (default).
     - `interruptable` means it can be stopped immediately.
+    - `forever` means it will be looping forever and can be interrupted.
 - `repeat`: defines how many times a part is replayed before moving to next. (optional)
 
 

--- a/data/glowing-logo/animation.toml
+++ b/data/glowing-logo/animation.toml
@@ -6,5 +6,4 @@ file = "part2.mp4"
 
 [[part]]
 file = "part2.mp4"
-repeat = 100
-mode = "interruptable"
+mode = "forever"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -175,7 +175,7 @@ mod test {
     }
 
     #[test]
-    fn iterator() {
+    fn iterator_takes_repeat_under_consideration_when_returning() {
         let animation = valid_toml();
         let mut animation: AnimationIter = animation.into_iter();
 


### PR DESCRIPTION
The possibility if providing a last part, which might be played forever
until interrupted is interesting as it allow for an arbitrary time for
finish the boot process.

One restriction is that the forever mode can only be used as a last
part, or it will never move to the next.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>