### PR TITLE
easysplash: Add EASYSPLASH_SINK_ARGS variable

### DIFF
--- a/etc/easysplash-quit.service.in
+++ b/etc/easysplash-quit.service.in
@@ -13,7 +13,7 @@ DefaultDependencies=no
 [Service]
 EnvironmentFile=-@SYSCONFDIR@/default/easysplash
 Type=oneshot
-ExecStart=@SBINDIR@/easysplash client --stop $EASYSPLASH_EXTRA_ARGS
+ExecStart=@SBINDIR@/easysplash client --stop $EASYSPLASH_VIDEOSINK_ARGS EASYSPLASH_EXTRA_ARGS
 TimeoutSec=30
 
 [Install]

--- a/etc/easysplash-start.init.in
+++ b/etc/easysplash-start.init.in
@@ -27,4 +27,4 @@ for x in $CMDLINE; do
 	esac
 done
 
-@SBINDIR@/easysplash open  /lib/easysplash/oem/animation /lib/easysplash/animation ${EASYSPLASH_EXTRA_ARGS} &
+@SBINDIR@/easysplash open  /lib/easysplash/oem/animation /lib/easysplash/animation ${EASYSPLASH_VIDEOSINK_ARGS} ${EASYSPLASH_EXTRA_ARGS} &

--- a/etc/easysplash-start.service.in
+++ b/etc/easysplash-start.service.in
@@ -14,7 +14,7 @@ DefaultDependencies=no
 [Service]
 EnvironmentFile=-@SYSCONFDIR@/default/easysplash
 Type=notify
-ExecStart=@SBINDIR@/easysplash open /lib/easysplash/oem/animation /lib/easysplash/animation $EASYSPLASH_EXTRA_ARGS
+ExecStart=@SBINDIR@/easysplash open /lib/easysplash/oem/animation /lib/easysplash/animation $EASYSPLASH_VIDEOSINK_ARGS $EASYSPLASH_EXTRA_ARGS
 
 [Install]
 WantedBy=sysinit.target

--- a/etc/easysplash.default
+++ b/etc/easysplash.default
@@ -5,4 +5,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
+EASYSPLASH_VIDEOSINK_ARGS=""
+
 EASYSPLASH_EXTRA_ARGS="--runtime-dir /run/easysplash --log info"


### PR DESCRIPTION
Add EASYSPLASH_SINK_ARGS variable on eashsplash services. Add variable
to set video-sink argument for gstreamer pipeline. Changed files are:
    - etc/easysplash.default
    - etc/easysplash-start.init.in
    - etc/easysplash-quit.service.in
    - etc/easysplash-start.service.in

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>