### PR TITLE
adjust systemd services, add boot prameter to skip splash

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ This is the help screen of EasySplash when ran with the -h argument:
       open              open the render with the specific animation
       client            control the render from the user space
 
+Boot parameters:
+    easysplash.enable If you want to skip the EasySplash on system boot set up
+                      this to "0".
 
 Animation format
 ----------------

--- a/etc/easysplash-quit.service.in
+++ b/etc/easysplash-quit.service.in
@@ -14,6 +14,7 @@ DefaultDependencies=no
 EnvironmentFile=-@SYSCONFDIR@/default/easysplash
 Type=oneshot
 ExecStart=@SBINDIR@/easysplash client --stop $EASYSPLASH_EXTRA_ARGS
+RemainAfterExit=yes
 TimeoutSec=30
 
 [Install]

--- a/etc/easysplash-start.service.in
+++ b/etc/easysplash-start.service.in
@@ -10,11 +10,16 @@ Description=Start EasySplash Boot screen
 Wants=systemd-vconsole-setup.service
 After=systemd-vconsole-setup.service systemd-udev-trigger.service systemd-udevd.service
 DefaultDependencies=no
+ConditionKernelCommandLine=!easysplash.enable=0
+ConditionVirtualization=!container
+IgnoreOnIsolate=true
 
 [Service]
 EnvironmentFile=-@SYSCONFDIR@/default/easysplash
 Type=notify
 ExecStart=@SBINDIR@/easysplash open /lib/easysplash/oem/animation /lib/easysplash/animation $EASYSPLASH_EXTRA_ARGS
+RemainAfterExit=yes
+KillMode=mixed
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
Hi,

i added couple of changes to systemd services.

`RemainAfterExit=yes `- by adding this you will ge th information if service was executed
`ConditionVirtualization=!container` - hardly make no sense to execute splash in cointainers
`IgnoreOnIsolate=true` - don't stop this service while related were stopped
`KillMode=mixed` - let's kill process in mixed mode
`ConditionKernelCommandLine=!easysplash.enable=0` - allow to skip easysplash if `easysplash.enable=0` was passed in boot parameters