### PR TITLE
Fix nightly build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,16 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,11 +618,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if",
  "value-bag",
 ]
 
@@ -1029,13 +1018,9 @@ checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
+checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ argh = "0.1.10"
 async-std = { version = "1.12.0", features = ["attributes", "unstable"] }
 derive_more = { version = "0.99.17", default-features = false, features = ["display", "from", "error"] }
 gst = { version = "0.20.5", package = "gstreamer", default-features = false }
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4.18", default-features = false }
 serde = { version = "1.0.160", features = ["derive"] }
 simple-logging = "2.0.2"
 toml = "0.7.3"


### PR DESCRIPTION
Currently, `master` is not building on nightly Rust:

```bash
$> uname -a
Linux my_machine 5.19.0-43-generic #44~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon May 22 13:39:36 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
$> cargo --version
cargo 1.72.0-nightly (f7b95e316 2023-05-30)
$> cargo +nightly build
   Compiling toml v0.7.3
   Compiling value-bag v1.0.0-alpha.9
   Compiling proc-macro-crate v1.3.1
   Compiling crossbeam-utils v0.8.11
   Compiling num-rational v0.4.1
   Compiling thiserror v1.0.40
error: to use a constant of type `TypeId` in a pattern, `TypeId` must be annotated with `#[derive(PartialEq, Eq)]`
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/value-bag-1.0.0-alpha.9/src/internal/cast/primitive.rs:43:33
   |
43 |                                   $const_ident => |v| Some(Internal::from(unsafe { &*(*v as *const Self as *const $ty) })),
   |                                   ^^^^^^^^^^^^
...
71 | /         to_internal![
72 | |             usize: (USIZE, OPTION_USIZE),
73 | |             u8: (U8, OPTION_U8),
74 | |             u16: (U16, OPTION_U16),
...  |
96 | |             String: (STRING, OPTION_STRING),
97 | |         ];
   | |_________- in this macro invocation
   |
   = note: the traits must be derived, manual `impl`s are not sufficient
   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
   = note: this error originates in the macro `to_internal` (in Nightly builds, run with -Z macro-backtrace for more info)

error: to use a constant of type `TypeId` in a pattern, `TypeId` must be annotated with `#[derive(PartialEq, Eq)]`
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/value-bag-1.0.0-alpha.9/src/internal/cast/primitive.rs:46:33
   |
46 |                                   $option_ident => |v| Some({
   |                                   ^^^^^^^^^^^^^
...
71 | /         to_internal![
72 | |             usize: (USIZE, OPTION_USIZE),
73 | |             u8: (U8, OPTION_U8),
74 | |             u16: (U16, OPTION_U16),
...  |
96 | |             String: (STRING, OPTION_STRING),
97 | |         ];
   | |_________- in this macro invocation
   |
   = note: the traits must be derived, manual `impl`s are not sufficient
   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
   = note: this error originates in the macro `to_internal` (in Nightly builds, run with -Z macro-backtrace for more info)

error: to use a constant of type `TypeId` in a pattern, `TypeId` must be annotated with `#[derive(PartialEq, Eq)]`
  --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/value-bag-1.0.0-alpha.9/src/internal/cast/primitive.rs:55:29
   |
55 |                               STR => |v| Some(Internal::from(unsafe { &**(v as *const &'a Self as *const &'a str) })),
   |                               ^^^
...
71 | /         to_internal![
72 | |             usize: (USIZE, OPTION_USIZE),
73 | |             u8: (U8, OPTION_U8),
74 | |             u16: (U16, OPTION_U16),
...  |
96 | |             String: (STRING, OPTION_STRING),
97 | |         ];
   | |_________- in this macro invocation
   |
   = note: the traits must be derived, manual `impl`s are not sufficient
   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralEq.html for details
   = note: this error originates in the macro `to_internal` (in Nightly builds, run with -Z macro-backtrace for more info)

   Compiling signal-hook v0.3.14
error: could not compile `value-bag` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```

According to the above error, the crate `value-bag` is not compiling. The crate `value-bag` is not listed in `Cargo.toml`, so it must be an indirect dependency of EasySplash.

By using the `cargo tree` command, we see that the `value-bag` crate is a dependency of `log`:

```bash
$> cargo tree
# ...
│   │   │   ├── log v0.4.17
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   └── value-bag v1.0.0-alpha.9
# ...
```

Poking around on the repo for the `log` crate, we find [a very similar compiler error](https://github.com/rust-lang/log/issues/564#issuecomment-1565657560). It seems the maintainers of the log crate fixed the compiler error in `v0.4.18` of the `log` crate.

Sure enough, after bumping `log` to `v0.4.18`, EasySplash compiles as normal with nightly Rust on my machine again:

```bash
$> cargo +nightly build
   Compiling autocfg v1.1.0
   Compiling proc-macro2 v1.0.56
   # ...
   Compiling gstreamer v0.20.5
   Compiling easysplash v1.90.0 (/home/nicholas/Documents/Rust/EasySplash)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 07s
```
